### PR TITLE
[DM-6126] Add patch to fix building with GCC 5.x on modern linux distributions.

### DIFF
--- a/patches/001-IncorrectTestForIsNaN.patch
+++ b/patches/001-IncorrectTestForIsNaN.patch
@@ -1,0 +1,46 @@
+diff --git a/util/permutedsort.c b/util/permutedsort.c
+index f329481..5cbcbf5 100644
+--- a/util/permutedsort.c
++++ b/util/permutedsort.c
+@@ -94,6 +94,11 @@ int* permuted_sort(const void* realarray, int array_stride,
+ 
+ 	//printf("d1=%g, d2=%g\n", d1, d2);				   
+ 
++#define INTCOMPARE(i1, i2, op1, op2)					\
++	if (i1 op1 i2) return -1;							\
++	if (i1 op2 i2) return 1;							\
++	return 0;
++
+ int compare_doubles_asc(const void* v1, const void* v2) {
+ 	const double d1 = *(double*)v1;
+ 	const double d2 = *(double*)v2;
+@@ -120,15 +125,15 @@ int compare_floats_desc(const void* v1, const void* v2) {
+ }
+ 
+ int compare_int64_asc(const void* v1, const void* v2) {
+-	int64_t f1 = *(int64_t*)v1;
+-	int64_t f2 = *(int64_t*)v2;
+-	COMPARE(f1, f2, <, >);
++	int64_t i1 = *(int64_t*)v1;
++	int64_t i2 = *(int64_t*)v2;
++	INTCOMPARE(i1, i2, <, >);
+ }
+ 
+ int compare_int64_desc(const void* v1, const void* v2) {
+-	int64_t f1 = *(int64_t*)v1;
+-	int64_t f2 = *(int64_t*)v2;
+-	COMPARE(f1, f2, >, <);
++	int64_t i1 = *(int64_t*)v1;
++	int64_t i2 = *(int64_t*)v2;
++	INTCOMPARE(i1, i2, >, <);
+ }
+ 
+ // Versions for use with QSORT_R
+@@ -139,6 +144,7 @@ int QSORT_COMPARISON_FUNCTION(compare_floats_asc_r,
+ 
+ 
+ #undef COMPARE
++#undef INTCOMPARE
+ 
+ int compare_ints_asc(const void* v1, const void* v2) {
+ 	const int d1 = *(int*)v1;


### PR DESCRIPTION
Add a patch to address this compiler error which happens on Ubuntu 16.04 due to GCC 5.x incompatibility:

'''
permutedsort.c:125:2: error: non-floating-point argument in call to function '__builtin_isnan'
  COMPARE(f1, f2, <, >);
...
permutedsort.c:131:2: error: non-floating-point argument in call to function '__builtin_isnan'
  COMPARE(f1, f2, >, <);
'''

[Mailing list discussion](https://groups.google.com/forum/#!topic/astrometry/aDCjhfMYhpE)

[GitHub commit](https://github.com/dstndstn/astrometry.net/commit/7ded70917d7cf1efa1d3af6d0da8b336ebbf9d92)
